### PR TITLE
README.md: document diagram output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ Pass a custom schema path (defaults to `ent/schema`):
 enter ./pkg/ent/schema
 ```
 
+Open `er.html` in web browser to view the diagram:
+
 ![ERD](https://user-images.githubusercontent.com/7413593/113307613-00f7d800-930e-11eb-8d22-0627b5dfd41d.png)


### PR DESCRIPTION
Document the output path (currently hardcoded as `er.html`) to avoid confusion when the user runs `enter` and it exits without saying anything.